### PR TITLE
Add new unittest suite

### DIFF
--- a/tests/test_audit_engine.py
+++ b/tests/test_audit_engine.py
@@ -1,12 +1,46 @@
+"""Tests for :mod:`audit_engine`."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import db
 import audit_engine
+import report_db
 
 
-def test_run_audit_creates_db(tmp_path):
-    original = db.DB_PATH
-    db.DB_PATH = tmp_path / 'test.db'
-    db.init_db()
-    results = audit_engine.run_audit()
-    assert db.DB_PATH.exists()
-    assert results
-    db.DB_PATH = original
+class AuditEngineTests(unittest.TestCase):
+    """Validate that running the audit writes expected records."""
+
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.original_path = db.DB_PATH
+        db.DB_PATH = Path(self.tmp.name) / "audit.db"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self.original_path
+        self.tmp.cleanup()
+
+    def test_run_audit_creates_db_and_sections(self) -> None:
+        """Ensure ``run_audit`` creates all sections and the DB file."""
+
+        results = audit_engine.run_audit()
+
+        # Database file should be created
+        self.assertTrue(db.DB_PATH.exists())
+
+        # There should be a result for every audit section
+        self.assertEqual(len(results), 10)
+        self.assertTrue(all(r.status == "PASS" for r in results))
+
+        # Verify records persisted via the reporting helper
+        run = report_db.fetch_last_run(db_path=db.DB_PATH)
+        self.assertEqual(len(run.get("sections", [])), 10)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
+

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,16 +1,40 @@
+"""Unit tests for :mod:`data_validator`."""
+
+from __future__ import annotations
+
+import unittest
+
 import data_validator
 
 
-def test_validate_email():
-    assert data_validator.validate_email('user@example.com')
-    assert not data_validator.validate_email('invalid')
+class DataValidatorTests(unittest.TestCase):
+    """Validate the small helper functions used for input checking."""
+
+    def test_validate_email(self) -> None:
+        self.assertTrue(data_validator.validate_email("user@example.com"))
+        self.assertFalse(data_validator.validate_email("invalid"))
+
+    def test_validate_domain(self) -> None:
+        self.assertTrue(data_validator.validate_domain("example.com"))
+        self.assertFalse(data_validator.validate_domain("no spaces"))
+
+    def test_validate_url(self) -> None:
+        self.assertTrue(data_validator.validate_url("https://example.com"))
+        self.assertTrue(data_validator.validate_url("http://foo.bar/baz"))
+        self.assertFalse(data_validator.validate_url("ftp://example.com"))
+
+    def test_is_positive_int(self) -> None:
+        self.assertTrue(data_validator.is_positive_int("5"))
+        self.assertFalse(data_validator.is_positive_int("0"))
+        self.assertFalse(data_validator.is_positive_int("-3"))
+        self.assertFalse(data_validator.is_positive_int("abc"))
+
+    def test_sanitize_filename(self) -> None:
+        name = data_validator.sanitize_filename("bad/name\\file.txt")
+        self.assertNotIn("/", name)
+        self.assertNotIn("\\", name)
 
 
-def test_validate_domain():
-    assert data_validator.validate_domain('example.com')
-    assert not data_validator.validate_domain('no spaces')
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
 
-
-def test_sanitize_filename():
-    name = data_validator.sanitize_filename('bad/name\\file.txt')
-    assert '/' not in name and '\\' not in name

--- a/tests/test_db_report.py
+++ b/tests/test_db_report.py
@@ -1,0 +1,79 @@
+"""Tests covering :mod:`db` and :mod:`report_db`."""
+
+from __future__ import annotations
+
+import sqlite3
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import db
+import report_db
+
+
+class DBReportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "gaudit.db"
+        self.original_path = db.DB_PATH
+        db.DB_PATH = self.db_path
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self.original_path
+        self.tmp.cleanup()
+
+    def test_init_db_creates_tables(self) -> None:
+        """Verify that all expected tables are created."""
+
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        names = {row[0] for row in cur.fetchall()}
+        conn.close()
+
+        expected = {"finding", "raw_object", "run", "section", "stat"}
+        self.assertTrue(expected.issubset(names))
+
+    def test_insert_and_fetch_data(self) -> None:
+        """Insert records via :mod:`db` and read them back with :mod:`report_db`."""
+
+        run_id = db.create_run()
+        sec_id = db.start_section(run_id, "Example")
+        db.insert_finding(sec_id, "ERROR", "oops")
+        db.insert_stat(sec_id, "k", "v")
+        db.complete_section(sec_id)
+
+        fetched = report_db.fetch_run(run_id, db_path=self.db_path)
+
+        self.assertEqual(fetched["id"], run_id)
+        self.assertEqual(len(fetched["sections"]), 1)
+
+        section = fetched["sections"][0]
+        self.assertEqual(section["name"], "Example")
+        self.assertEqual(section["status"], "complete")
+        self.assertEqual(section["findings"][0]["message"], "oops")
+        self.assertEqual(section["stats"][0]["value"], "v")
+
+    def test_fetch_last_run_empty(self) -> None:
+        """``fetch_last_run`` should return an empty dict with no data."""
+
+        self.assertEqual(report_db.fetch_last_run(db_path=self.db_path), {})
+
+    def test_fetch_last_run_returns_latest(self) -> None:
+        run1 = db.create_run()
+        sec1 = db.start_section(run1, "One")
+        db.complete_section(sec1)
+
+        run2 = db.create_run()
+        sec2 = db.start_section(run2, "Two")
+        db.complete_section(sec2)
+
+        last = report_db.fetch_last_run(db_path=self.db_path)
+        self.assertEqual(last["id"], run2)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
+

--- a/tests/test_secure_store.py
+++ b/tests/test_secure_store.py
@@ -1,0 +1,44 @@
+"""Tests for :mod:`secure_store` using a fake in-memory keyring."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+
+
+class SecureStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Provide a dummy keyring module before importing secure_store
+        self.storage: dict[tuple[str, str], str] = {}
+        self.fake_keyring = types.SimpleNamespace(
+            set_password=lambda svc, user, pw: self.storage.__setitem__((svc, user), pw),
+            get_password=lambda svc, user: self.storage.get((svc, user)),
+        )
+        self.orig_keyring = sys.modules.get("keyring")
+        sys.modules["keyring"] = self.fake_keyring
+        import secure_store
+
+        self.secure_store = importlib.reload(secure_store)
+
+    def tearDown(self) -> None:
+        if self.orig_keyring is not None:
+            sys.modules["keyring"] = self.orig_keyring
+        else:
+            sys.modules.pop("keyring", None)
+
+    def test_round_trip_credentials(self) -> None:
+        data = b"secret"
+        self.secure_store.save_credentials(data)
+        loaded = self.secure_store.load_credentials()
+        self.assertEqual(loaded, data)
+
+    def test_load_invalid_data_returns_none(self) -> None:
+        self.storage[("GAuditV2", "credentials")] = "not base64"  # type: ignore[index]
+        self.assertIsNone(self.secure_store.load_credentials())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- rewrite existing tests to use `unittest`
- add new tests for database helpers and report helpers
- add tests for secure credential storage
- expand input validation tests
- verify audit engine writes sections to the DB

## Testing
- `python -m unittest discover -s tests -v`