### PR TITLE
Add runtime validation for DB functions

### DIFF
--- a/data_validator.py
+++ b/data_validator.py
@@ -44,6 +44,22 @@ def is_positive_int(value: str) -> bool:
     return value.isdigit() and int(value) > 0
 
 
+def ensure_positive_int(value: int, name: str = "value") -> int:
+    """Return ``value`` if it is a positive ``int`` else raise ``ValueError``."""
+
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def ensure_non_empty_str(value: str, name: str = "value") -> str:
+    """Return ``value`` if it is a non-empty ``str`` else raise ``ValueError``."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
 def sanitize_filename(name: str, replacement: str = "_") -> str:
     """Return ``name`` stripped of path separators and invalid characters."""
 

--- a/db.py
+++ b/db.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
+import data_validator
+
 DB_PATH = Path("gaudit.db")
 
 # Tracks section start times to calculate duration
@@ -103,6 +105,9 @@ def create_run() -> int:
 
 def start_section(run_id: int, name: str) -> int:
     """Start tracking an audit section."""
+    data_validator.ensure_positive_int(run_id, "run_id")
+    data_validator.ensure_non_empty_str(name, "name")
+
     conn = _get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -119,6 +124,8 @@ def start_section(run_id: int, name: str) -> int:
 
 def complete_section(section_id: int) -> None:
     """Mark an audit section as complete."""
+    data_validator.ensure_positive_int(section_id, "section_id")
+
     start_time = _section_start_times.pop(section_id, None)
     duration = None
     if start_time is not None:
@@ -136,6 +143,10 @@ def complete_section(section_id: int) -> None:
 
 def insert_finding(section_id: int, severity: str, message: str) -> None:
     """Record a security finding."""
+    data_validator.ensure_positive_int(section_id, "section_id")
+    data_validator.ensure_non_empty_str(severity, "severity")
+    data_validator.ensure_non_empty_str(message, "message")
+
     conn = _get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -148,6 +159,10 @@ def insert_finding(section_id: int, severity: str, message: str) -> None:
 
 def insert_stat(section_id: int, key: str, value: str) -> None:
     """Store a statistic for an audit section."""
+    data_validator.ensure_positive_int(section_id, "section_id")
+    data_validator.ensure_non_empty_str(key, "key")
+    data_validator.ensure_non_empty_str(value, "value")
+
     conn = _get_conn()
     cur = conn.cursor()
     cur.execute(
@@ -160,6 +175,10 @@ def insert_stat(section_id: int, key: str, value: str) -> None:
 
 def insert_raw(section_id: int, raw_data: bytes) -> None:
     """Save raw audit data."""
+    data_validator.ensure_positive_int(section_id, "section_id")
+    if not isinstance(raw_data, (bytes, bytearray)):
+        raise ValueError("raw_data must be bytes-like")
+
     conn = _get_conn()
     cur = conn.cursor()
     cur.execute(

--- a/report_db.py
+++ b/report_db.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import sqlite3
 from typing import Any, Iterable
 
+import data_validator
+
 
 DB_FILE = Path("gaudit.db")
 
@@ -79,6 +81,8 @@ def fetch_last_run(*, db_path: str | Path = DB_FILE) -> dict:
 def fetch_run(run_id: int, *, db_path: str | Path = DB_FILE) -> dict:
     """Return a specific run by ``run_id`` including its sections."""
 
+    data_validator.ensure_positive_int(run_id, "run_id")
+
     conn, close_conn = _ensure_conn(db_path)
     try:
         row = conn.execute(
@@ -104,6 +108,8 @@ def fetch_sections(
     conn: sqlite3.Connection | None = None,
 ) -> list[dict]:
     """Return a list of sections for ``run_id`` with findings and stats."""
+
+    data_validator.ensure_positive_int(run_id, "run_id")
 
     conn, close_conn = _ensure_conn(db_path, conn)
     try:
@@ -133,6 +139,8 @@ def fetch_findings(
 ) -> list[dict]:
     """Return all findings for ``section_id``."""
 
+    data_validator.ensure_positive_int(section_id, "section_id")
+
     conn, close_conn = _ensure_conn(db_path, conn)
     try:
         cur = conn.execute(
@@ -155,6 +163,8 @@ def fetch_stats(
 ) -> list[dict]:
     """Return all statistics for ``section_id``."""
 
+    data_validator.ensure_positive_int(section_id, "section_id")
+
     conn, close_conn = _ensure_conn(db_path, conn)
     try:
         cur = conn.execute(
@@ -174,6 +184,8 @@ def fetch_raw_objects(
     conn: sqlite3.Connection | None = None,
 ) -> list[dict]:
     """Return raw objects associated with ``section_id`` if available."""
+
+    data_validator.ensure_positive_int(section_id, "section_id")
 
     conn, close_conn = _ensure_conn(db_path, conn)
     try:

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -34,6 +34,16 @@ class DataValidatorTests(unittest.TestCase):
         self.assertNotIn("/", name)
         self.assertNotIn("\\", name)
 
+    def test_ensure_positive_int(self) -> None:
+        self.assertEqual(data_validator.ensure_positive_int(5), 5)
+        with self.assertRaises(ValueError):
+            data_validator.ensure_positive_int(0)
+
+    def test_ensure_non_empty_str(self) -> None:
+        self.assertEqual(data_validator.ensure_non_empty_str("ok"), "ok")
+        with self.assertRaises(ValueError):
+            data_validator.ensure_non_empty_str("  ")
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()

--- a/tests/test_db_report.py
+++ b/tests/test_db_report.py
@@ -73,6 +73,16 @@ class DBReportTests(unittest.TestCase):
         last = report_db.fetch_last_run(db_path=self.db_path)
         self.assertEqual(last["id"], run2)
 
+    def test_invalid_inputs_raise_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            db.start_section(0, "bad")
+        run_id = db.create_run()
+        sec_id = db.start_section(run_id, "Good")
+        with self.assertRaises(ValueError):
+            db.insert_finding(sec_id, "", "msg")
+        with self.assertRaises(ValueError):
+            report_db.fetch_run(0, db_path=self.db_path)
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     unittest.main()


### PR DESCRIPTION
## Summary
- validate IDs and strings used in database helpers
- expose new helpers in `data_validator`
- test the new validation logic

## Testing
- `python -m unittest discover tests -v`