### PR TITLE
Add module documentation and docstrings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,18 @@
+"""Top-level package for GAudit V2.
+
+This package organizes the core modules used by the GAudit application.
+The architecture is intentionally simple:
+
+- :mod:`main_window` contains the PyQt6 based GUI used to run and review
+  audits.
+- :mod:`audit_engine` houses the security checks executed during an audit
+  and records results in the SQLite database managed by :mod:`db`.
+- :mod:`report_exporter` and :mod:`report_db` provide helpers for
+  generating human readable reports from stored audit data.
+- :mod:`analytics_tabs` offers small widgets that visualise results for
+  specific areas such as authentication or Drive security.
+
+Additional utilities such as :mod:`credential_loader` and
+:mod:`secure_store` handle authentication and credential storage.  The
+application entry point is :func:`main.main` which launches the GUI.
+"""

--- a/analytics_tabs/__init__.py
+++ b/analytics_tabs/__init__.py
@@ -1,0 +1,7 @@
+"""Analytics tab widgets used by the GAudit GUI.
+
+Each submodule defines a small :class:`PyQt6.QtWidgets.QWidget` that
+presents statistics and findings for a specific portion of the audit.
+Tabs are instantiated by :class:`main_window.MainWindow` and populate the
+QTabWidget shown to the user.
+"""

--- a/analytics_tabs/authentication_analytics_tab.py
+++ b/analytics_tabs/authentication_analytics_tab.py
@@ -24,6 +24,8 @@ class AuthenticationAnalyticsTab(QWidget):
     """Widget displaying authentication-related analytics."""
 
     def __init__(self) -> None:
+        """Initialise the tab and create child widgets."""
+
         super().__init__()
         self._chart_factory = ChartFactory()
 

--- a/analytics_tabs/drive_analytics_tab.py
+++ b/analytics_tabs/drive_analytics_tab.py
@@ -20,6 +20,8 @@ class DriveAnalyticsTab(QWidget):
     """Widget showing Drive security statistics and findings."""
 
     def __init__(self) -> None:
+        """Create the tab and set up the user interface."""
+
         super().__init__()
         self._setup_ui()
 

--- a/analytics_tabs/email_security_analytics_tab.py
+++ b/analytics_tabs/email_security_analytics_tab.py
@@ -28,6 +28,8 @@ class EmailSecurityAnalyticsTab(QWidget):
     """Display Gmail security statistics and findings."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
+        """Construct the tab layout and widgets."""
+
         super().__init__(parent)
 
         layout = QVBoxLayout(self)

--- a/analytics_tabs/group_analytics_tab.py
+++ b/analytics_tabs/group_analytics_tab.py
@@ -35,6 +35,8 @@ class GroupAnalyticsTab(QWidget):
     """UI widget for displaying group management analysis results."""
 
     def __init__(self) -> None:
+        """Initialise the widget and set up the UI."""
+
         super().__init__()
         self._init_ui()
 

--- a/analytics_tabs/users_ous_analytics_tab.py
+++ b/analytics_tabs/users_ous_analytics_tab.py
@@ -19,6 +19,8 @@ class UsersOUsAnalyticsTab(QWidget):
     """Display analytics for users and organizational units."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
+        """Set up the tree view used to present user and OU stats."""
+
         super().__init__(parent)
         self._layout = QVBoxLayout(self)
         self._title = QLabel("User and OU Analysis", self)

--- a/main_window.py
+++ b/main_window.py
@@ -35,11 +35,15 @@ class MainWindow(QtWidgets.QMainWindow):
         self._populate_tabs()
 
     def _create_status_bar(self) -> None:
+        """Initialise the status bar shown at the bottom of the window."""
+
         self._status = QtWidgets.QStatusBar()
         self.setStatusBar(self._status)
         self._status.showMessage("Ready")
 
     def _create_menus(self) -> None:
+        """Create the application menu bar and attach actions."""
+
         menubar = self.menuBar()
         audit_menu = menubar.addMenu("Audit")
         validate_action = QAction("Validate API", self)
@@ -64,6 +68,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self._tabs.addTab(widget, name)
 
     def _validate_api(self) -> None:
+        """Run API connectivity checks in a background thread."""
+
         dialog = ApiValidationStatusDialog(self)
         thread = ApiValidationThread(dialog)
         thread.progress.connect(dialog.update_status)
@@ -72,6 +78,8 @@ class MainWindow(QtWidgets.QMainWindow):
         thread.start()
 
     def _run_audit(self) -> None:
+        """Launch the audit process and show progress to the user."""
+
         settings_dialog = RunAuditSettingsDialog(self)
         if settings_dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             if settings_dialog.create_new_db.isChecked():
@@ -115,9 +123,13 @@ class ApiValidationThread(QtCore.QThread):
     progress = QtCore.pyqtSignal(str)
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        """Initialise the thread and store the optional ``parent`` widget."""
+
         super().__init__(parent)
 
     def run(self) -> None:  # type: ignore[override]
+        """Execute API validation and emit progress updates."""
+
         self.progress.emit("Validating APIs...")
         audit_engine.validate_api_services()
         self.progress.emit("Validation complete")
@@ -127,6 +139,8 @@ class ApiValidationStatusDialog(QtWidgets.QDialog):
     """Dialog to show API validation status."""
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        """Construct the dialog with an initial status label."""
+
         super().__init__(parent)
         self.setWindowTitle("API Validation")
         self._label = QtWidgets.QLabel("Starting validation...", self)
@@ -134,6 +148,8 @@ class ApiValidationStatusDialog(QtWidgets.QDialog):
         layout.addWidget(self._label)
 
     def update_status(self, message: str) -> None:
+        """Update the label text with ``message``."""
+
         self._label.setText(message)
 
 
@@ -141,6 +157,8 @@ class RunAuditSettingsDialog(QtWidgets.QDialog):
     """Dialog for configuring audit run parameters."""
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        """Create the settings dialog used before running an audit."""
+
         super().__init__(parent)
         self.setWindowTitle("Run Audit")
         layout = QtWidgets.QVBoxLayout(self)
@@ -163,6 +181,8 @@ class AuditWorker(QtCore.QThread):
     progress_updated = QtCore.pyqtSignal(str)
 
     def run(self) -> None:  # type: ignore[override]
+        """Execute the audit and emit progress messages."""
+
         self.progress_updated.emit("Starting audit")
         for section in audit_engine.run_audit():
             self.progress_updated.emit(f"Completed {section.name}")

--- a/report_exporter.py
+++ b/report_exporter.py
@@ -8,6 +8,8 @@ import report_db
 
 
 def _format_findings(findings: List[Dict[str, Any]]) -> str:
+    """Return HTML table rows for ``findings``."""
+
     rows = []
     for finding in findings:
         severity = finding.get("severity", "")
@@ -19,6 +21,8 @@ def _format_findings(findings: List[Dict[str, Any]]) -> str:
 
 
 def _format_stats(stats: Dict[str, Any]) -> str:
+    """Return HTML list items for statistic key/value pairs."""
+
     if not stats:
         return "<li>No statistics available</li>"
     return "\n".join(f"<li>{key}: {value}</li>" for key, value in stats.items())


### PR DESCRIPTION
## Summary
- document overall GAudit architecture in new `__init__.py`
- add overview for `analytics_tabs` package
- add missing docstrings in main window helpers and worker classes
- document tab constructors and report exporter helpers

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*