### PR TITLE
Add env override for database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,9 @@ GAudit provides a simple GUI for auditing Google Workspace environments. The imp
    python main.py
    ```
 
-Running the app will create `gaudit.db` in the working directory to store audit results.
+Running the app will create `gaudit.db` in the working directory. You can override this path by setting the `GAUDIT_DB_PATH` environment variable:
+
+```bash
+export GAUDIT_DB_PATH=/path/to/custom.db
+python main.py
+```

--- a/db.py
+++ b/db.py
@@ -1,4 +1,9 @@
-"""SQLite database helpers for GAudit V2."""
+"""SQLite database helpers for GAudit V2.
+
+The location of the SQLite database can be configured with the
+``GAUDIT_DB_PATH`` environment variable.  If not set, ``gaudit.db`` in the
+current working directory is used.
+"""
 
 from __future__ import annotations
 
@@ -6,9 +11,10 @@ import sqlite3
 import time
 from datetime import datetime
 from pathlib import Path
+import os
 from typing import Dict
 
-DB_PATH = Path("gaudit.db")
+DB_PATH = Path(os.environ.get("GAUDIT_DB_PATH", "gaudit.db"))
 
 # Tracks section start times to calculate duration
 _section_start_times: Dict[int, float] = {}

--- a/report_db.py
+++ b/report_db.py
@@ -15,16 +15,21 @@ tables::
 Only a subset of the schema is required for report generation.  The
 functions below provide convenient read access returning dictionaries so
 that report generation code can easily consume the stored audit data.
+
+The database location defaults to ``gaudit.db`` in the current working
+directory but can be overridden via the ``GAUDIT_DB_PATH`` environment
+variable.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+import os
 import sqlite3
 from typing import Any, Iterable
 
 
-DB_FILE = Path("gaudit.db")
+DB_FILE = Path(os.environ.get("GAUDIT_DB_PATH", "gaudit.db"))
 
 
 def _ensure_conn(


### PR DESCRIPTION
## Summary
- let db.py and report_db.py read `GAUDIT_DB_PATH` to determine database location
- document `GAUDIT_DB_PATH` usage in README

## Testing
- `python -m unittest discover -v tests`