### PR TITLE
Fix test cleanup for temporary database files

### DIFF
--- a/tests/test_audit_engine.py
+++ b/tests/test_audit_engine.py
@@ -16,13 +16,14 @@ class AuditEngineTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
         self.original_path = db.DB_PATH
         db.DB_PATH = Path(self.tmp.name) / "audit.db"
+        self.addCleanup(lambda: setattr(db, "DB_PATH", self.original_path))
         db.init_db()
 
     def tearDown(self) -> None:
         db.DB_PATH = self.original_path
-        self.tmp.cleanup()
 
     def test_run_audit_creates_db_and_sections(self) -> None:
         """Ensure ``run_audit`` creates all sections and the DB file."""

--- a/tests/test_db_report.py
+++ b/tests/test_db_report.py
@@ -14,14 +14,15 @@ import report_db
 class DBReportTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
         self.db_path = Path(self.tmp.name) / "gaudit.db"
         self.original_path = db.DB_PATH
         db.DB_PATH = self.db_path
+        self.addCleanup(lambda: setattr(db, "DB_PATH", self.original_path))
         db.init_db()
 
     def tearDown(self) -> None:
         db.DB_PATH = self.original_path
-        self.tmp.cleanup()
 
     def test_init_db_creates_tables(self) -> None:
         """Verify that all expected tables are created."""


### PR DESCRIPTION
## Summary
- prevent leftover DB files by ensuring cleanup functions are always run
- add cleanup callbacks in audit and report unit tests

## Testing
- `python -m unittest discover tests`