### PR TITLE
Clarify PDF dependency and handle wkhtmltopdf absence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ GAudit provides a simple GUI for auditing Google Workspace environments. The imp
    ```bash
    pip install -r requirements.txt
    ```
+   PDF export requires the `wkhtmltopdf` binary. On Debian/Ubuntu you can install it with:
+   ```bash
+   sudo apt-get install wkhtmltopdf
+   ```
+
 2. Run the application:
    ```bash
    python main.py

--- a/report_exporter.py
+++ b/report_exporter.py
@@ -68,4 +68,9 @@ def export_pdf_report(path: str) -> None:
         import pdfkit
     except ImportError as exc:  # pragma: no cover - optional dependency
         raise RuntimeError("pdfkit is required for PDF export") from exc
-    pdfkit.from_string(html, path)
+    try:
+        pdfkit.from_string(html, path)
+    except OSError as exc:  # pragma: no cover - missing wkhtmltopdf
+        raise RuntimeError(
+            "wkhtmltopdf is required for PDF export; install it system-wide"
+        ) from exc

--- a/tests/test_report_exporter.py
+++ b/tests/test_report_exporter.py
@@ -1,0 +1,21 @@
+import types
+import unittest
+from unittest import mock
+
+import report_exporter
+
+
+class ReportExporterTests(unittest.TestCase):
+    def test_export_pdf_missing_wkhtmltopdf(self) -> None:
+        fake_pdfkit = types.SimpleNamespace(
+            from_string=mock.Mock(side_effect=OSError("No wkhtmltopdf executable found"))
+        )
+        with mock.patch.dict("sys.modules", {"pdfkit": fake_pdfkit}):
+            with mock.patch("report_exporter.report_db.fetch_last_run", return_value={}):
+                with self.assertRaises(RuntimeError) as ctx:
+                    report_exporter.export_pdf_report("out.pdf")
+        self.assertIn("wkhtmltopdf", str(ctx.exception))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the wkhtmltopdf system package in the README
- raise a helpful error when wkhtmltopdf isn't installed
- test export_pdf_report error handling

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`