### PR TITLE
Enhance config handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ GAudit provides a simple GUI for auditing Google Workspace environments. The imp
 
 2. Run the application:
    ```bash
-   python main.py
-   ```
+python main.py
+```
 
 
 Running the app will create `gaudit.db` in the working directory. You can override this path by setting the `GAUDIT_DB_PATH` environment variable:
@@ -25,3 +25,27 @@ Running the app will create `gaudit.db` in the working directory. You can overri
 export GAUDIT_DB_PATH=/path/to/custom.db
 python main.py
 ```
+
+## Configuration
+
+GAudit reads additional settings from a JSON configuration file. By default the
+file `config.json` in the working directory is used. You can specify an
+alternative path via the `GAUDIT_CONFIG` environment variable. If the file does
+not exist, a default one will be created automatically.
+
+Example configuration structure:
+
+```json
+{
+  "api_services": [
+    "admin_sdk",
+    "drive_api",
+    "gmail_api",
+    "groups_settings_api"
+  ]
+}
+```
+
+The `validate_api_services()` helper consults environment variables named
+`GAUDIT_SERVICE_<SERVICE>` to simulate connectivity to individual APIs during
+testing.

--- a/db.py
+++ b/db.py
@@ -203,14 +203,8 @@ def create_run(
 
 def start_section(run_id: int, name: str) -> int:
     """Start tracking an audit section."""
-    with _managed_conn() as conn:
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO section (run_id, name, status) VALUES (?, ?, ?)",
-            (run_id, name, "in_progress"),
-        )
-        section_id = cur.lastrowid
-
+    _validate_positive_int(run_id, "run_id")
+    _validate_non_empty(name, "name")
     conn = _get_conn()
     try:
         cur = conn.cursor()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-auth
 keyring
 matplotlib
 pdfkit
+pydantic

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
+
+from pydantic import BaseModel, ValidationError
 
 DEFAULT_SETTINGS = {
     "api_services": [
@@ -15,15 +18,41 @@ DEFAULT_SETTINGS = {
 CONFIG_FILENAME = "config.json"
 
 
+logger = logging.getLogger(__name__)
+
+
+class SettingsModel(BaseModel):
+    api_services: list[str]
+
+
+def ensure_config_exists(path: Path | None = None) -> Path:
+    """Ensure a configuration file exists at ``path``."""
+    if path is None:
+        path = Path(os.getenv("GAUDIT_CONFIG", CONFIG_FILENAME))
+    if not path.exists():
+        logger.info("Creating default config at %s", path)
+        path.write_text(json.dumps(DEFAULT_SETTINGS, indent=2))
+    return path
+
+
 def load_settings(path: Path | None = None) -> Dict[str, Any]:
     """Load configuration from ``path`` or the default location."""
     if path is None:
-        path = Path(os.getenv("GAUDIT_CONFIG", CONFIG_FILENAME))
+        path = ensure_config_exists()
     try:
         with path.open(encoding="utf-8") as fh:
             data = json.load(fh)
     except FileNotFoundError:
+        logger.warning("Config file %s not found, using defaults", path)
         data = {}
-    # Merge with defaults
+    except json.JSONDecodeError as exc:
+        logger.error("Invalid JSON in config file %s", path)
+        raise ValueError("Invalid configuration file") from exc
+
     merged = {**DEFAULT_SETTINGS, **data}
-    return merged
+    try:
+        validated = SettingsModel(**merged)
+    except ValidationError as exc:
+        logger.error("Configuration validation error: %s", exc)
+        raise ValueError("Invalid configuration structure") from exc
+    return validated.dict()

--- a/tests/test_db_validation.py
+++ b/tests/test_db_validation.py
@@ -1,7 +1,20 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import db
 
 class DBValidationErrorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.original_path = db.DB_PATH
+        db.DB_PATH = Path(self.tmp.name) / "test.db"
+        db.init_db()
+
+    def tearDown(self) -> None:
+        db.DB_PATH = self.original_path
+        self.tmp.cleanup()
+
     def test_start_section_invalid_run_id(self):
         with self.assertRaises(ValueError):
             db.start_section(0, "name")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -8,12 +8,20 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
-from PyQt6.QtWidgets import QApplication, QDialog
+try:
+    from PyQt6.QtWidgets import QApplication, QDialog
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    QApplication = None  # type: ignore[assignment]
+    QDialog = None  # type: ignore[assignment]
 
-import db
-from main_window import MainWindow, RunAuditSettingsDialog, AuditWorker
+if QApplication is not None:
+    import db
+    from main_window import MainWindow, RunAuditSettingsDialog, AuditWorker
+else:  # pragma: no cover - optional dependency
+    db = None  # type: ignore[assignment]
 
 
+@unittest.skipIf(QApplication is None, "PyQt6 not available")
 class MainWindowGUITests(unittest.TestCase):
     """Basic GUI tests exercising the main window."""
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -23,6 +23,24 @@ class SettingsTests(unittest.TestCase):
             loaded = settings.load_settings(cfg)
             self.assertEqual(loaded["api_services"], ["one", "two"])
 
+    def test_default_file_created(self) -> None:
+        with TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "auto.json"
+            os.environ["GAUDIT_CONFIG"] = str(cfg)
+            try:
+                loaded = settings.load_settings()
+            finally:
+                os.environ.pop("GAUDIT_CONFIG", None)
+            self.assertTrue(cfg.exists())
+            self.assertIn("admin_sdk", loaded["api_services"])
+
+    def test_invalid_json_raises(self) -> None:
+        with TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / "bad.json"
+            cfg.write_text("{invalid")
+            with self.assertRaises(ValueError):
+                settings.load_settings(cfg)
+
 
 class ValidateApiServicesTests(unittest.TestCase):
     def test_validate_api_services_uses_custom_config(self) -> None:
@@ -35,6 +53,20 @@ class ValidateApiServicesTests(unittest.TestCase):
             finally:
                 os.environ.pop("GAUDIT_CONFIG", None)
             self.assertEqual(set(result.keys()), {"svc1", "svc2"})
+
+
+class EnvHelperTests(unittest.TestCase):
+    def test_env_int_and_bool(self) -> None:
+        os.environ["TEST_INT"] = "5"
+        os.environ["TEST_BOOL"] = "yes"
+        try:
+            self.assertEqual(audit_engine._env_int("TEST_INT", 0), 5)
+            self.assertTrue(audit_engine._env_bool("TEST_BOOL", False))
+            os.environ["TEST_INT"] = "notint"
+            self.assertEqual(audit_engine._env_int("TEST_INT", 3), 3)
+        finally:
+            os.environ.pop("TEST_INT", None)
+            os.environ.pop("TEST_BOOL", None)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution


### PR DESCRIPTION
## Summary
- add pydantic requirement
- validate configuration in `settings.load_settings`
- create default config when missing
- document configuration file usage
- fix duplicated insert in `db.start_section`
- update unit tests and add new cases
- skip GUI tests if PyQt6 is absent

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`